### PR TITLE
Add string type support to module.sources

### DIFF
--- a/doc2json.py
+++ b/doc2json.py
@@ -57,6 +57,7 @@ def handle_property(name: str, variable_info: dict, entry_dict: dict):
         variable_info['type'] = 'array'
         variable_info['items'] = {
             'anyOf': [
+                {'type': 'string'},
                 {'$ref': '#/definitions/archive-source'},
                 {'$ref': '#/definitions/git-source'},
                 {'$ref': '#/definitions/bzr-source'},

--- a/flatpak-manifest.schema
+++ b/flatpak-manifest.schema
@@ -158,6 +158,9 @@
           "items": {
             "anyOf": [
               {
+                "type": "string"
+              },
+              {
                 "$ref": "#/definitions/archive-source"
               },
               {


### PR DESCRIPTION
According to flatpak-manifest manpage:

Additionally, the sources list can contain a plain string, which is interpreted
as the name of a separate json or yaml file that is read and inserted at
this point.